### PR TITLE
Improved submitting the model and start time

### DIFF
--- a/CommonData.json
+++ b/CommonData.json
@@ -296,5 +296,73 @@
                                                                  "type": "integer"
                                                       } ]
                                   }
+                },
+        "Time": {
+                    "TIME_START_HIGH": {
+                                      "category": "Time",
+                                  "control_type": "display",
+                                   "description": "Start time high bits in seconds",
+                                    "identifier": "TIME_START_HIGH",
+                                        "inputs": [  ],
+                                       "outputs": [ {
+                                                          "address": 1092,
+                                                      "description": "Start time high bits in seconds",
+                                                             "mask": 65535,
+                                                        "max_value": 65535,
+                                                         "shift_by": 0,
+                                                           "suffix": "",
+                                                             "type": "integer"
+                                                  } ]
+                              },
+                    "TIME_START_LOW": {
+                                      "category": "Time",
+                                  "control_type": "display",
+                                   "description": "Start time low bits in seconds",
+                                    "identifier": "TIME_START_LOW",
+                                        "inputs": [  ],
+                                       "outputs": [ {
+                                                          "address": 1094,
+                                                      "description": "Start time low bits in seconds",
+                                                             "mask": 65535,
+                                                        "max_value": 65535,
+                                                         "shift_by": 0,
+                                                           "suffix": "",
+                                                             "type": "integer"
+                                                  } ]
+                              },
+
+                    "TIME_MODEL_HIGH": {
+                                      "category": "Time",
+                                  "control_type": "display",
+                                   "description": "Model time high bits in hundredth of a second",
+                                    "identifier": "TIME_MODEL_HIGH",
+                                        "inputs": [  ],
+                                       "outputs": [ {
+                                                          "address": 1096,
+                                                      "description": "Model time high bits in hundredth of a second",
+                                                             "mask": 65535,
+                                                        "max_value": 65535,
+                                                         "shift_by": 0,
+                                                           "suffix": "",
+                                                             "type": "integer"
+                                                  } ]
+                              },
+                    "TIME_MODEL_LOW": {
+                                      "category": "Time",
+                                  "control_type": "display",
+                                   "description": "Model time low bits in hundredth of a second",
+                                    "identifier": "TIME_MODEL_LOW",
+                                        "inputs": [  ],
+                                       "outputs": [ {
+                                                          "address": 1098,
+                                                      "description": "Model Time low bits in hundredth of a second",
+                                                             "mask": 65535,
+                                                        "max_value": 65535,
+                                                         "shift_by": 0,
+                                                           "suffix": "",
+                                                             "type": "integer"
+                                                  } ]
+                              }
+
                 }
 }

--- a/CommonData.lua
+++ b/CommonData.lua
@@ -12,6 +12,10 @@ local altFt = 0
 local hdgDeg
 local hdgDegFrac = 0
 local iasDisp
+local startTimeLow = 0
+local startTimeHigh = 0
+local modTimeLow = 0
+local modTimeHigh = 0
 
 moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
 	-- skip  this data if ownship export is disabled
@@ -20,11 +24,17 @@ moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
 	playerName = LoGetPilotName()
 		if playerName == nil then playerName = "XXX" end
 	
-	misstime = string.format(LoGetMissionStartTime())
-		if misstime == nil then misstime = "0" end
-		
-	modtime = string.format("%5.0f", LoGetModelTime())
-		if modtime == nil then modtime = "0" end
+	
+	local startTime = LoGetMissionStartTime() or 0
+	misstime = string.format(startTime)
+	startTimeLow = startTime%65536
+	startTimeHigh = (startTime - startTimeLow)/65536
+	
+	local modTimeFloat = LoGetModelTime() or 0	
+	modtime = string.format("%5.0f", modTimeFloat)
+	local modTimeHundredth = math.floor (modTimeFloat*100)
+	modTimeLow = modTimeHundredth%65536
+	modTimeHigh = (modTimeHundredth - modTimeLow) / 65536
 			
 	iasDisp = LoGetIndicatedAirSpeed()
 		if iasDisp == nil then iasDisp = "0000" end
@@ -124,5 +134,10 @@ end, 127, "Heading", "Heading (Fractional Degrees, divide by 127)")
 
 defineString("MISS_TIME",  misstime, 5, "Metadata", "Mission Start Time")
 defineString("MOD_TIME", function() return modtime or "00000" end, 5, "Metadata", "Model Time in sec")
+
+defineIntegerFromGetter("TIME_START_HIGH", function() return startTimeHigh end, 65535, "Time", "Start time high bits in seconds")
+defineIntegerFromGetter("TIME_START_LOW", function() return startTimeLow end, 65535, "Time", "Start time low bits in seconds")
+defineIntegerFromGetter("TIME_MODEL_HIGH", function() return modTimeHigh end, 65535, "Time", "Model time high bits in hundredth of a second")
+defineIntegerFromGetter("TIME_MODEL_LOW", function() return modTimeLow end, 65535, "Time", "Model time low bits in hundredth of a second")
 
 BIOS.protocol.endModule()


### PR DESCRIPTION
Hello,

I also thought about adding the start and model time a few month ago (for being able to build a hardware clock and a stop watch that bases on the dcs time).
My first attemp also used string values to submit the time, but since I played on multiplayer servers from time to time I realized that using 5 or 6 bytes for the model time will overrun after not even 1.5 days of mission time.
Moreover comparing time values is much easier if you do not need to transfer the strings into long (number) values.
Since a normal integer (two) bytes (=65536) is also not sufficient I split the time values into a higher and lower integer value.
Even with submitting the model time in a hundredth of a second I am now able to join missions that run for more than a year (this will probably never happen).
It is also very easy to convert the two (high and low integer) integer values into a single (unsigned) long value by using arithmetic or bit functions.

So please give consideration to merge the pull request.

